### PR TITLE
ci: remove pull_request_target to prevent secret exfil from fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,15 @@ name: main
 on:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
       - '**.md'
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - .github/workflows/ci.yml
 
 concurrency: ${{ github.workflow }}--${{ github.ref }}
+
+permissions:
+  contents: read
 
 jobs:
   main:
@@ -27,15 +26,11 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Decrypt keyfile
-        run: ./.github/scripts/decrypt_secret.sh
-        env:
-          KEYFILE_PASSPHRASE: ${{secrets.KEYFILE_PASSPHRASE}}
+          persist-credentials: false
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{matrix.node-version}}
       - name: Install dependencies
@@ -44,7 +39,17 @@ jobs:
         run: corepack yarn build
       - name: Run linters
         run: corepack yarn lint
+      # Integration tests need AWS + a decrypted GCS keyfile. Skip on fork PRs
+      # because secrets are unavailable in that context by design (replaces
+      # the previous pull_request_target trigger which exposed secrets to
+      # attacker-controlled PR code; see TanStack/router#7383).
+      - name: Decrypt keyfile
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        run: ./.github/scripts/decrypt_secret.sh
+        env:
+          KEYFILE_PASSPHRASE: ${{secrets.KEYFILE_PASSPHRASE}}
       - name: Run tests
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         run: corepack yarn test
         env:
           AWS_BUCKET: ${{secrets.AWS_BUCKET}}


### PR DESCRIPTION
Removes the `pull_request_target` trigger from CI, which previously checked out fork-PR code and ran `yarn install`/`yarn test` with AWS credentials and a GPG passphrase in env (the canonical pwn-request pattern, per TanStack/router#7383 and the GitHub Security Lab "pwn requests" writeup). The workflow now runs on plain `pull_request`, with the decrypt-keyfile and test steps gated behind a check that the PR originates from the base repo, so fork PRs no longer have access to those secrets.

Also pins `actions/checkout` and `actions/setup-node` to commit SHAs, sets `persist-credentials: false` on checkout, and adds a workflow-level `contents: read` permission.

Push to `main` and in-repo PRs keep running the full suite; fork PRs run build and lint only.